### PR TITLE
Add OnlyFans Telegram bot prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# chat
+# OnlyFans Telegram Bot
+
+Prototype de bot Telegram pour automatiser les conversations et l'upsell sur OnlyFans.
+
+## Fonctionnalités
+- Réponses automatiques via un LLM (OpenAI).
+- Génération de messages vocaux avec ElevenLabs.
+- Logique d'upsell : après quelques messages, envoi d'un vocal puis proposition de contenu vidéo via un lien PPV.
+- Configuration simple via `config.yaml`.
+
+## Installation
+```bash
+pip install -r requirements.txt
+```
+
+## Variables d'environnement
+- `TELEGRAM_BOT_TOKEN`
+- `OPENAI_API_KEY`
+- `ELEVEN_API_KEY`
+
+## Lancement
+```bash
+python -m bot.main
+```
+
+## Tests
+```bash
+pytest
+```

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+# Telegram OnlyFans automation bot package

--- a/bot/llm.py
+++ b/bot/llm.py
@@ -1,0 +1,15 @@
+import openai
+from typing import List, Dict
+
+
+class LLMClient:
+    """Wrapper around an LLM API (e.g., OpenAI)."""
+
+    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
+        openai.api_key = api_key
+        self.model = model
+
+    def generate_reply(self, conversation: List[Dict[str, str]]) -> str:
+        """Return the assistant's reply given the conversation history."""
+        response = openai.ChatCompletion.create(model=self.model, messages=conversation)
+        return response["choices"][0]["message"]["content"].strip()

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,68 @@
+import io
+import logging
+import os
+import yaml
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    ContextTypes,
+    MessageHandler,
+    CommandHandler,
+    filters,
+)
+
+from .llm import LLMClient
+from .voice import VoiceClient
+from .upsell import UpsellManager
+
+
+logging.basicConfig(level=logging.INFO)
+
+CONFIG_PATH = os.environ.get("BOT_CONFIG", "config.yaml")
+with open(CONFIG_PATH) as fh:
+    CONFIG = yaml.safe_load(fh)
+
+llm_client = LLMClient(os.environ.get("OPENAI_API_KEY", ""), CONFIG.get("llm_model", "gpt-3.5-turbo"))
+voice_client = VoiceClient(os.environ.get("ELEVEN_API_KEY", ""), CONFIG.get("voice_id", ""))
+upsell = UpsellManager(CONFIG.get("free_message_limit", 3))
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(CONFIG.get("welcome_message", "Salut!"))
+
+
+async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.message.from_user.id
+    text = update.message.text
+    upsell.record_message(user_id)
+
+    history = context.user_data.setdefault("history", [])
+    history.append({"role": "user", "content": text})
+    reply = llm_client.generate_reply(history)
+    history.append({"role": "assistant", "content": reply})
+    await update.message.reply_text(reply)
+
+    if upsell.needs_voice_offer(user_id):
+        audio = voice_client.synthesize(reply)
+        bio = io.BytesIO(audio)
+        bio.name = "voice.mp3"
+        await update.message.reply_voice(voice=bio)
+        upsell.record_voice_sent(user_id)
+        await update.message.reply_text(CONFIG.get("voice_upsell", """Pour aller plus loin, clique ici: {link}""").format(link=CONFIG.get("ppv_link", "")))
+    elif upsell.needs_video_offer(user_id):
+        upsell.record_video_offered(user_id)
+        await update.message.reply_text(CONFIG.get("video_upsell", """Envie d'une vidéo? {link}""").format(link=CONFIG.get("video_link", "")))
+
+
+def main() -> None:
+    token = os.environ["TELEGRAM_BOT_TOKEN"]
+    app = ApplicationBuilder().token(token).build()
+
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), handle_message))
+
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/bot/upsell.py
+++ b/bot/upsell.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from collections import defaultdict
+
+
+@dataclass
+class UserState:
+    """State for a single user in the upsell flow."""
+
+    messages: int = 0
+    voice_offered: bool = False
+    voice_sent: bool = False
+    video_offered: bool = False
+
+
+class UpsellManager:
+    """Tracks interaction state and decides when to propose paid content."""
+
+    def __init__(self, free_message_limit: int = 3):
+        self.free_message_limit = free_message_limit
+        self._states: dict[int, UserState] = defaultdict(UserState)
+
+    def record_message(self, user_id: int) -> None:
+        self._states[user_id].messages += 1
+
+    def needs_voice_offer(self, user_id: int) -> bool:
+        state = self._states[user_id]
+        return state.messages >= self.free_message_limit and not state.voice_offered
+
+    def record_voice_offered(self, user_id: int) -> None:
+        self._states[user_id].voice_offered = True
+
+    def record_voice_sent(self, user_id: int) -> None:
+        state = self._states[user_id]
+        state.voice_sent = True
+        state.voice_offered = True
+
+    def needs_video_offer(self, user_id: int) -> bool:
+        state = self._states[user_id]
+        return state.voice_sent and not state.video_offered
+
+    def record_video_offered(self, user_id: int) -> None:
+        self._states[user_id].video_offered = True

--- a/bot/voice.py
+++ b/bot/voice.py
@@ -1,0 +1,17 @@
+import requests
+
+
+class VoiceClient:
+    """Generate speech audio via ElevenLabs API."""
+
+    def __init__(self, api_key: str, voice_id: str):
+        self.api_key = api_key
+        self.voice_id = voice_id
+
+    def synthesize(self, text: str) -> bytes:
+        url = f"https://api.elevenlabs.io/v1/text-to-speech/{self.voice_id}"
+        headers = {"xi-api-key": self.api_key, "Content-Type": "application/json"}
+        payload = {"text": text}
+        response = requests.post(url, json=payload, headers=headers)
+        response.raise_for_status()
+        return response.content

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+welcome_message: "Salut mon fan! Je suis ravie de te parler."
+llm_model: gpt-3.5-turbo
+voice_id: "your-voice-id"
+free_message_limit: 3
+ppv_link: "https://onlyfans.com/ppv-placeholder"
+video_link: "https://onlyfans.com/video-placeholder"
+voice_upsell: "Tu veux entendre plus de moi ? Clique ici : {link}"
+video_upsell: "Pour une vidéo exclusive, c'est par ici : {link}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-telegram-bot>=20.0
+openai>=0.27
+PyYAML
+requests

--- a/tests/test_upsell.py
+++ b/tests/test_upsell.py
@@ -1,0 +1,18 @@
+from bot.upsell import UpsellManager
+
+
+def test_voice_offer_trigger():
+    upsell = UpsellManager(free_message_limit=3)
+    user_id = 1
+    for _ in range(3):
+        upsell.record_message(user_id)
+    assert upsell.needs_voice_offer(user_id)
+
+
+def test_video_offer_after_voice():
+    upsell = UpsellManager(free_message_limit=1)
+    user_id = 2
+    upsell.record_message(user_id)
+    assert upsell.needs_voice_offer(user_id)
+    upsell.record_voice_sent(user_id)
+    assert upsell.needs_video_offer(user_id)


### PR DESCRIPTION
## Summary
- Add prototype Telegram bot with ChatGPT responses, voice synthesis, and upsell logic
- Provide configuration via YAML and documented setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b87301fb748321860209578d5c40f4