### PR TITLE
Add tests for LLM and voice clients and message handler

### DIFF
--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,50 @@
+import types
+import openai
+import requests
+from bot.llm import LLMClient
+from bot.voice import VoiceClient
+
+
+def test_llm_client_generates_reply(monkeypatch):
+    calls = {}
+
+    def fake_create(*, model, messages):
+        calls["model"] = model
+        calls["messages"] = messages
+        return {"choices": [{"message": {"content": "Bonjour"}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    client = LLMClient(api_key="test", model="test-model")
+    conv = [{"role": "user", "content": "Salut"}]
+    reply = client.generate_reply(conv)
+
+    assert reply == "Bonjour"
+    assert calls["model"] == "test-model"
+    assert calls["messages"] == conv
+
+
+class DummyResponse:
+    def __init__(self, content=b"audio"):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+def test_voice_client_synthesize(monkeypatch):
+    api_key = "key"
+    voice_id = "voice123"
+
+    def fake_post(url, json, headers):
+        assert url == f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+        assert json == {"text": "Hello"}
+        assert headers["xi-api-key"] == api_key
+        return DummyResponse(b"data")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    client = VoiceClient(api_key, voice_id)
+    result = client.synthesize("Hello")
+
+    assert result == b"data"

--- a/tests/test_handle_message.py
+++ b/tests/test_handle_message.py
@@ -1,0 +1,71 @@
+import asyncio
+from types import SimpleNamespace
+from telegram import Update
+from telegram.ext import Application, CallbackContext
+
+from bot.main import handle_message, llm_client, voice_client, upsell, CONFIG
+
+
+class DummyMessage:
+    def __init__(self, text, user_id):
+        self.text = text
+        self.from_user = SimpleNamespace(id=user_id)
+        self.texts = []
+        self.voices = []
+
+    async def reply_text(self, text, **kwargs):
+        self.texts.append(text)
+
+    async def reply_voice(self, voice, **kwargs):
+        self.voices.append(voice)
+
+
+def build_context(user_id):
+    app = Application.builder().token("TEST").build()
+    return CallbackContext(application=app, chat_id=user_id, user_id=user_id)
+
+
+def test_handle_message_text_only(monkeypatch):
+    message = DummyMessage("Bonjour", 42)
+    update = Update(update_id=1, message=message)
+    context = build_context(42)
+
+    monkeypatch.setattr(llm_client, "generate_reply", lambda history: "Salut" )
+    monkeypatch.setattr(upsell, "record_message", lambda uid: None)
+    monkeypatch.setattr(upsell, "needs_voice_offer", lambda uid: False)
+    monkeypatch.setattr(upsell, "needs_video_offer", lambda uid: False)
+
+    asyncio.run(handle_message(update, context))
+
+    assert message.texts == ["Salut"]
+    assert message.voices == []
+    assert context.user_data["history"] == [
+        {"role": "user", "content": "Bonjour"},
+        {"role": "assistant", "content": "Salut"},
+    ]
+
+
+def test_handle_message_with_voice(monkeypatch):
+    message = DummyMessage("Bonjour", 1)
+    update = Update(update_id=2, message=message)
+    context = build_context(1)
+
+    monkeypatch.setattr(llm_client, "generate_reply", lambda history: "Salut" )
+    synth_calls = []
+
+    def fake_synthesize(text):
+        synth_calls.append(text)
+        return b"data"
+
+    monkeypatch.setattr(voice_client, "synthesize", fake_synthesize)
+    monkeypatch.setattr(upsell, "record_message", lambda uid: None)
+    monkeypatch.setattr(upsell, "needs_voice_offer", lambda uid: True)
+    monkeypatch.setattr(upsell, "needs_video_offer", lambda uid: False)
+    monkeypatch.setattr(upsell, "record_voice_sent", lambda uid: None)
+
+    asyncio.run(handle_message(update, context))
+
+    assert message.texts[0] == "Salut"
+    assert message.texts[1] == CONFIG["voice_upsell"].format(link=CONFIG["ppv_link"])
+    assert len(message.voices) == 1
+    assert synth_calls == ["Salut"]


### PR DESCRIPTION
## Summary
- add unit tests for LLMClient and VoiceClient using mocked APIs
- add integration tests for handle_message through a simulated telegram Application

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b94c73ec64832186134e663c5226b9